### PR TITLE
Set orientation matching the aspect ratio when printing

### DIFF
--- a/src/wxForms/VisualizationSpeedButtonPanel.cpp
+++ b/src/wxForms/VisualizationSpeedButtonPanel.cpp
@@ -284,6 +284,10 @@ void VisualizationSpeedButtonPanel::OnPeakFind( wxCommandEvent &event )
 void VisualizationSpeedButtonPanel::OnPrintDrawing( wxCommandEvent &WXUNUSED(event) )
 {
   wxPrintData *printData( ExGlobals::GetPrintData() );
+
+  // Select orientation matching the current aspect ratio.
+  printData->SetOrientation( ExGlobals::GetAspectRatio() >= 1 ? wxPORTRAIT : wxLANDSCAPE );
+
   wxPrintDialogData printDialogData( *printData );
   wxPrinter printer( &printDialogData );
   MyPrintout printout( wxT("Extrema printing") );


### PR DESCRIPTION
Use portrait or landscape to match the shape of the visualization
window.

See #29.

---

This is a trivial change, of course, but I'm submitting it for the review because after testing it I'm not really sure if it's a good idea: you don't see the orientation in the dialog until you go and look for it and IMO it could be surprising for the user for it to change just because they've changed the aspect ratio. But maybe I'm just worrying too much...