### PR TITLE
Fix wrong initial size of the visualization window graphics

### DIFF
--- a/src/wxForms/VisualizationWindow.cpp
+++ b/src/wxForms/VisualizationWindow.cpp
@@ -196,12 +196,13 @@ VisualizationWindow::VisualizationWindow( wxWindow *parent )
   // earlier could crash due to using e.g. uninitialized "notebook_" field.
   mainPanel_->Bind(wxEVT_SIZE, &VisualizationWindow::OnSize, this);
 
+  // Call this before LayoutMainPanel() which will use it.
+  ExGlobals::SetAspectRatio( aspectRatio );
+
   SetClientSize(size);
   mainPanel_->SetSize(size);
   LayoutMainPanel();
 
-  ExGlobals::SetMonitorLimits( 0, 0, size.x, size.y );
-  ExGlobals::SetAspectRatio( aspectRatio );
   page->ResetWindows();
 
   // Show the window.


### PR DESCRIPTION
We need to set the aspect ration before laying out the pages as
ResetPages() function used by layout code uses the current aspect
ration.

We also don't need to call SetMonitorLimits() at all, as this is already
done by ResetPages() and, in fact, calling it here replaced the correct
limits set there with wrong ones (as the size here is the frame size and
not the graphics page size at all).