### PR TITLE
Don't use wxLogDebug() resulting in tons of output

### DIFF
--- a/src/Graphics/GRA_drawableText.cpp
+++ b/src/Graphics/GRA_drawableText.cpp
@@ -179,7 +179,7 @@ wxFont MakeFont( GRA_wxWidgets* graphicsOutput, GRA_simpleText* text )
   font.SetPointSize( h );
   font.SetWeight( text->GetWeight() );
   font.SetStyle( text->GetStyle() );
-  wxLogDebug("GRA_drawableText::MakeFont: world height=%g, font height=%d, style=%d(%d), weight=%d(%d)", 
+  wxLogTrace("font", "GRA_drawableText::MakeFont: world height=%g, font height=%d, style=%d(%d), weight=%d(%d)",
           height, h, text->GetStyle(), wxFONTSTYLE_NORMAL, text->GetWeight(), wxFONTWEIGHT_NORMAL);
   return font;
 }


### PR DESCRIPTION
This is annoying and mostly unnecessary, as it's only useful when
debugging font-related problems and not always.

Use wxLogTrace() which allows to enable this output, by setting WXTRACE
environment variable to "font", only when it's really wanted.